### PR TITLE
Shuffle algorithm objects

### DIFF
--- a/Xyaneon.Games.Cards/DefaultShuffleAlgorithm.cs
+++ b/Xyaneon.Games.Cards/DefaultShuffleAlgorithm.cs
@@ -10,7 +10,7 @@ namespace Xyaneon.Games.Cards
     /// <typeparam name="TCard">
     /// The <see cref="Type"/> of cards this algorithm will be used to shuffle.
     /// </typeparam>
-    public class DefaultShuffleAlgorithm<TCard> : IShuffleAlgorithm<TCard> where TCard : Card
+    public sealed class DefaultShuffleAlgorithm<TCard> : IShuffleAlgorithm<TCard> where TCard : Card
     {
         #region IShuffleAlgorithm<TCard> implementation
 

--- a/Xyaneon.Games.Cards/DefaultShuffleAlgorithm.cs
+++ b/Xyaneon.Games.Cards/DefaultShuffleAlgorithm.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xyaneon.Games.Cards
+{
+    /// <summary>
+    /// A default shuffling algorithm for cards.
+    /// </summary>
+    /// <typeparam name="TCard">
+    /// The <see cref="Type"/> of cards this algorithm will be used to shuffle.
+    /// </typeparam>
+    public class DefaultShuffleAlgorithm<TCard> : IShuffleAlgorithm<TCard> where TCard : Card
+    {
+        #region IShuffleAlgorithm<TCard> implementation
+
+        /// <summary>
+        /// Shuffles the provided collection of cards and returns them in a new
+        /// <see cref="IList{T}"/> indicating the shuffled order.
+        /// </summary>
+        /// <param name="cards">
+        /// The collection of cards to shuffle.
+        /// </param>
+        /// <returns>
+        /// A new list containing the supplied <paramref name="cards"/>
+        /// in shuffled order.
+        /// </returns>
+        public IList<TCard> Shuffle(IEnumerable<TCard> cards)
+        {
+            var random = new Random();
+            return cards.OrderBy(c => random.Next()).ToList();
+        }
+
+        #endregion // End IShuffleAlgorithm<TCard> implementation region.
+    }
+}

--- a/Xyaneon.Games.Cards/IShuffleAlgorithm.cs
+++ b/Xyaneon.Games.Cards/IShuffleAlgorithm.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xyaneon.Games.Cards
+{
+    /// <summary>
+    /// Interface for classes which can be used for shuffling cards.
+    /// </summary>
+    /// <typeparam name="TCard">
+    /// The <see cref="Type"/> of cards this algorithm will be used to shuffle.
+    /// </typeparam>
+    public interface IShuffleAlgorithm<TCard> where TCard : Card
+    {
+        #region Methods
+
+        /// <summary>
+        /// Shuffles the provided collection of cards and returns them in a new
+        /// <see cref="IList{T}"/> indicating the shuffled order.
+        /// </summary>
+        /// <param name="cards">
+        /// The collection of cards to shuffle.
+        /// </param>
+        /// <returns>
+        /// A new list containing the supplied <paramref name="cards"/>
+        /// in shuffled order.
+        /// </returns>
+        IList<TCard> Shuffle(IEnumerable<TCard> cards);
+
+        #endregion // End methods region.
+    }
+}

--- a/Xyaneon.Games.Cards/Xyaneon.Games.Cards.xml
+++ b/Xyaneon.Games.Cards/Xyaneon.Games.Cards.xml
@@ -201,16 +201,24 @@
             Shuffles all of the cards in this <see cref="T:Xyaneon.Games.Cards.DrawPile`1"/>
             using a default shuffling algorithm.
             </summary>
+            <remarks>
+            This method will use the shuffling algorithm provided by the
+            <see cref="T:Xyaneon.Games.Cards.DefaultShuffleAlgorithm`1"/>. If you want to use
+            a custom shuffling method instead, then consider using the
+            <see cref="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle(Xyaneon.Games.Cards.IShuffleAlgorithm{`0})"/> overload method.
+            </remarks>
         </member>
-        <member name="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle(System.Func{System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IList{`0}})">
+        <member name="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle(Xyaneon.Games.Cards.IShuffleAlgorithm{`0})">
             <summary>
             Shuffles all of the cards in this <see cref="T:Xyaneon.Games.Cards.DrawPile`1"/>
             using the supplied shuffling algorithm.
             </summary>
             <param name="shuffleAlgorithm">
-            The delegate to use which implements the custom shuffling
-            algorithm.
+            The object providing the shuffling algorithm to use.
             </param>
+            <exception cref="T:System.ArgumentNullException">
+            <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
+            </exception>
         </member>
         <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleIn(System.Collections.Generic.IEnumerable{`0})">
             <summary>
@@ -224,8 +232,15 @@
             <exception cref="T:System.ArgumentNullException">
             <paramref name="cards"/> is <see langword="null"/>.
             </exception>
+            <remarks>
+            This method will use the shuffling algorithm provided by the
+            <see cref="T:Xyaneon.Games.Cards.DefaultShuffleAlgorithm`1"/>. If you want to use
+            a custom shuffling method instead, then consider using the
+            <see cref="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleIn(System.Collections.Generic.IEnumerable{`0},Xyaneon.Games.Cards.IShuffleAlgorithm{`0})"/>
+            overload method.
+            </remarks>
         </member>
-        <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleIn(System.Collections.Generic.IEnumerable{`0},System.Func{System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IList{`0}})">
+        <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleIn(System.Collections.Generic.IEnumerable{`0},Xyaneon.Games.Cards.IShuffleAlgorithm{`0})">
             <summary>
             Shuffles the provided <paramref name="cards"/> into this
             <see cref="T:Xyaneon.Games.Cards.DrawPile`1"/> using the supplied shuffling
@@ -236,43 +251,38 @@
             <see cref="T:Xyaneon.Games.Cards.DrawPile`1"/>.
             </param>
             <param name="shuffleAlgorithm">
-            The delegate to use which implements the custom shuffling
-            algorithm.
+            The object providing the shuffling algorithm to use.
             </param>
             <exception cref="T:System.ArgumentNullException">
             <paramref name="cards"/> is <see langword="null"/>.
+            -or-
+            <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
             </exception>
         </member>
-        <member name="M:Xyaneon.Games.Cards.DrawPile`1.DefaultShuffleAlgorithm(System.Collections.Generic.IEnumerable{`0})">
-            <summary>
-            Provides the default shuffling algorithm used by this class.
-            </summary>
-            <param name="cards">
-            The collection of cards to shuffle.
-            </param>
-            <returns>
-            A new list containing the supplied <paramref name="cards"/>
-            in shuffled order.
-            </returns>
-        </member>
-        <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleBase(System.Func{System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IList{`0}})">
+        <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleBase(Xyaneon.Games.Cards.IShuffleAlgorithm{`0})">
             <summary>
             The base method for shuffling the cards stored in this object.
             The <paramref name="shuffleAlgorithm"/> must always be specified.
             </summary>
             <param name="shuffleAlgorithm">
-            The delegate to use which implements the desired shuffling
-            algorithm.
+            The object providing the shuffling algorithm to use.
             </param>
             <remarks>
+            <para>
+            This method assumes that the <paramref name="shuffleAlgorithm"/>
+            parameter supplied was already checked to not be
+            <see langword="null"/> by the caller.
+            </para>
+            <para>
             The <paramref name="shuffleAlgorithm"/> supplied can just be the
-            <see cref="M:Xyaneon.Games.Cards.DrawPile`1.DefaultShuffleAlgorithm(System.Collections.Generic.IEnumerable{`0})"/> method
-            defined within this class for default behavior, such as when called
-            by the public <see cref="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle"/> method. However, an
-            alternative can be supplied when needed.
+            <see cref="T:Xyaneon.Games.Cards.DefaultShuffleAlgorithm`1"/> class defined in this
+            library for default behavior, such as when called by the public
+            <see cref="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle"/> method. However, an alternative can be
+            supplied when needed.
+            </para>
             </remarks>
         </member>
-        <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleInBase(System.Collections.Generic.IEnumerable{`0},System.Func{System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IList{`0}})">
+        <member name="M:Xyaneon.Games.Cards.DrawPile`1.ShuffleInBase(System.Collections.Generic.IEnumerable{`0},Xyaneon.Games.Cards.IShuffleAlgorithm{`0})">
             <summary>
             The base method for shuffling the supplied <paramref name="cards"/>
             into this <see cref="T:Xyaneon.Games.Cards.DrawPile`1"/>. The
@@ -283,21 +293,19 @@
             <see cref="T:Xyaneon.Games.Cards.DrawPile`1"/>.
             </param>
             <param name="shuffleAlgorithm">
-            The delegate to use which implements the desired shuffling
-            algorithm.
+            The object providing the shuffling algorithm to use.
             </param>
             <remarks>
             <para>
-            This method assumes that the <paramref name="cards"/> parameter
-            supplied was already checked to not be <see langword="null"/> by
-            the caller.
+            This method assumes that the parameters supplied were already
+            checked to not be <see langword="null"/> by the caller.
             </para>
             <para>
             The <paramref name="shuffleAlgorithm"/> supplied can just be the
-            <see cref="M:Xyaneon.Games.Cards.DrawPile`1.DefaultShuffleAlgorithm(System.Collections.Generic.IEnumerable{`0})"/> method
-            defined within this class for default behavior, such as when called
-            by the public <see cref="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle"/> method. However, an
-            alternative can be supplied when needed.
+            <see cref="T:Xyaneon.Games.Cards.DefaultShuffleAlgorithm`1"/> class defined in this
+            library for default behavior, such as when called by the public
+            <see cref="M:Xyaneon.Games.Cards.DrawPile`1.Shuffle"/> method. However, an alternative can be
+            supplied when needed.
             </para>
             </remarks>
         </member>

--- a/Xyaneon.Games.Cards/Xyaneon.Games.Cards.xml
+++ b/Xyaneon.Games.Cards/Xyaneon.Games.Cards.xml
@@ -10,6 +10,27 @@
             Cannot be directly instantiated.
             </summary>
         </member>
+        <member name="T:Xyaneon.Games.Cards.DefaultShuffleAlgorithm`1">
+            <summary>
+            A default shuffling algorithm for cards.
+            </summary>
+            <typeparam name="TCard">
+            The <see cref="T:System.Type"/> of cards this algorithm will be used to shuffle.
+            </typeparam>
+        </member>
+        <member name="M:Xyaneon.Games.Cards.DefaultShuffleAlgorithm`1.Shuffle(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Shuffles the provided collection of cards and returns them in a new
+            <see cref="T:System.Collections.Generic.IList`1"/> indicating the shuffled order.
+            </summary>
+            <param name="cards">
+            The collection of cards to shuffle.
+            </param>
+            <returns>
+            A new list containing the supplied <paramref name="cards"/>
+            in shuffled order.
+            </returns>
+        </member>
         <member name="T:Xyaneon.Games.Cards.DrawPile`1">
             <summary>
             A collection of cards which can be drawn from.
@@ -279,6 +300,27 @@
             alternative can be supplied when needed.
             </para>
             </remarks>
+        </member>
+        <member name="T:Xyaneon.Games.Cards.IShuffleAlgorithm`1">
+            <summary>
+            Interface for classes which can be used for shuffling cards.
+            </summary>
+            <typeparam name="TCard">
+            The <see cref="T:System.Type"/> of cards this algorithm will be used to shuffle.
+            </typeparam>
+        </member>
+        <member name="M:Xyaneon.Games.Cards.IShuffleAlgorithm`1.Shuffle(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Shuffles the provided collection of cards and returns them in a new
+            <see cref="T:System.Collections.Generic.IList`1"/> indicating the shuffled order.
+            </summary>
+            <param name="cards">
+            The collection of cards to shuffle.
+            </param>
+            <returns>
+            A new list containing the supplied <paramref name="cards"/>
+            in shuffled order.
+            </returns>
         </member>
     </members>
 </doc>


### PR DESCRIPTION
Instead of using a delegate for specifying shuffle algorithms, use a new `IShuffleAlgorithm<TCard>` interface to indicate that an object provides shuffling functionality and pass that in instead.