### PR TITLE
Fix DrawPile place at bottom method

### DIFF
--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -84,5 +84,39 @@ namespace Xyaneon.Games.Cards.Test
             Assert.IsTrue(expectedCardSet.SetEquals(new HashSet<IntCard>(drawnCards)));
             Assert.AreEqual(0, drawPile.Cards.Count);
         }
+
+        /// <summary>
+        /// Tests the <see cref="DrawPile{TCard}.PlaceAtBottom"/> method.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_PlaceAtBottomTest()
+        {
+            // Arrange.
+            var expectedCards = new IntCard[]
+            {
+                // 3 (new top), 2, 1, 4 (new bottom)
+                new IntCard(3), new IntCard(2), new IntCard(1), new IntCard(4)
+            };
+            var cards = new IntCard[]
+            {
+                // 1 (old bottom), 2, 3, 4 (old top)
+                new IntCard(1), new IntCard(2), new IntCard(3), new IntCard(4)
+            };
+            var drawPile = new DrawPile<IntCard>(cards);
+            List<IntCard> actualCards;
+
+            // Act.
+            var drawnCard = drawPile.Draw();
+            drawPile.PlaceAtBottom(drawnCard); // place card with value 4 at the bottom
+            actualCards = new List<IntCard>(drawPile.Cards);
+
+            // Assert.
+            // Use collections assertions for lists because HashSet is unable to compare different sets.
+            // Otherwise, GetHashCode and Equals methods would have to be tamed.
+            CollectionAssert.AreEqual(expectedCards, actualCards, Comparer<IntCard>.Create((a, b) =>
+            {
+                return a.Value - b.Value;
+            }));
+        }
     }
 }

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -252,8 +252,7 @@ namespace Xyaneon.Games.Cards
             {
                 throw new ArgumentNullException(nameof(card), "The card to place at the bottom of the draw pile cannot be null.");
             }
-
-            _cards = new Stack<TCard>(_cards.Concat(new TCard[] { card }));
+            _cards = new Stack<TCard>(new TCard[] { card }.Concat(_cards.Reverse()));
         }
 
         /// <summary>


### PR DESCRIPTION
Address the `DrawPile` place at bottom issue by using proper `Stack` mechanics.

Also will add a test to make sure the method runs correctly.

Closes #14 