### PR TITLE
Revert "Specify Xenial instead of Bionic in Travis."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dist: xenial
+dist: bionic
 dotnet: 2.2.103
 solution: Xyaneon.Games.Cards.sln
 script:


### PR DESCRIPTION
This reverts commit 11a3c03c31e2f3e2601edede295162b837a953d2 and fixes #17.