### PR TITLE
bump: Upgrade MSTest dependencies

### DIFF
--- a/Xyaneon.Games.Cards.Test/Xyaneon.Games.Cards.Test.csproj
+++ b/Xyaneon.Games.Cards.Test/Xyaneon.Games.Cards.Test.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded MSTest.TestAdapter and MSTest.TestFramework to version 2.2.8 per this post: https://stackoverflow.com/a/70704102

This is done manually to address testing failures seen in Dependabot pull requests #27 and #28.