### PR TITLE
chore: Use semantic-release-nuget for package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,8 @@ jobs:
     - name: Test
       run: dotnet test -c Release --no-build --verbosity normal
     
-    - name: Semantic Release dry run to get new Semantic Version
-      env:
-        GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE }}
-      run: npx semantic-release --dry-run
-    
-    - name: Build with new Semantic Version
-      run: dotnet build -c Release --no-restore -p:Version=${{ env.RELEASE_VERSION }}
-    
-    - name: Package
-      run: dotnet pack -c Release --no-build --include-symbols -p:Version=${{ env.RELEASE_VERSION }} -o dist/
-    
     - name: Semantic Release
       env:
         GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE }}
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
       run: npx semantic-release
-    
-    - name: Publish package on NuGet
-      run: dotnet nuget push dist/*.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Semantic Release
       env:
         GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE }}
+        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
       run: npx semantic-release
     
     - name: Publish package on NuGet

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -37,6 +37,12 @@
             }
         ],
         [
+            "@droidsolutions-oss/semantic-release-nuget",
+            {
+                "includeSymbols": true
+            }
+        ],
+        [
             "@semantic-release/git",
             {
                 "assets": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "@droidsolutions-oss/semantic-release-nuget": "^1.1.1",
         "@droidsolutions-oss/semantic-release-update-file": "^1.2.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -120,6 +121,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@droidsolutions-oss/semantic-release-nuget": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@droidsolutions-oss/semantic-release-nuget/-/semantic-release-nuget-1.1.1.tgz",
+      "integrity": "sha512-woB3Yss10OPg9JOV28gIC/cnfC3mFYcO7A3DcW/KOxnY5GV/bWe7+t1yUjg1LztCUuFlh0aNp9vxXNvNovteBA==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=15.14.0"
       }
     },
     "node_modules/@droidsolutions-oss/semantic-release-update-file": {
@@ -6066,6 +6079,15 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
+    },
+    "@droidsolutions-oss/semantic-release-nuget": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@droidsolutions-oss/semantic-release-nuget/-/semantic-release-nuget-1.1.1.tgz",
+      "integrity": "sha512-woB3Yss10OPg9JOV28gIC/cnfC3mFYcO7A3DcW/KOxnY5GV/bWe7+t1yUjg1LztCUuFlh0aNp9vxXNvNovteBA==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.1.1"
+      }
     },
     "@droidsolutions-oss/semantic-release-update-file": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@droidsolutions-oss/semantic-release-nuget": "^1.1.1",
     "@droidsolutions-oss/semantic-release-update-file": "^1.2.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/commit-analyzer": "^9.0.2",


### PR DESCRIPTION
Uses the [`@droidsolutions-oss/semantic-release-nuget`](https://www.npmjs.com/package/@droidsolutions-oss/semantic-release-nuget) Semantic Release plugin in place of the scripting and version number workaround used previously.

Fixes #34.