### PR TITLE
feat: change target back to .NET 2.0 Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Package Icon][icon]
 
-A .NET 6.0 library for playing cards (standard and custom), draw piles
+A .NET Standard 2.0 library for playing cards (standard and custom), draw piles
 and shuffling.
 
 ## Usage

--- a/Xyaneon.Games.Cards.Test/Xyaneon.Games.Cards.Test.csproj
+++ b/Xyaneon.Games.Cards.Test/Xyaneon.Games.Cards.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Xyaneon.Games.Cards/Xyaneon.Games.Cards.csproj
+++ b/Xyaneon.Games.Cards/Xyaneon.Games.Cards.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>A library for playing cards (standard and custom), draw piles and shuffling.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Xyaneon/Xyaneon.Games.Cards</PackageProjectUrl>


### PR DESCRIPTION
Since .NET 6.0 actually supports .NET Standard 2.0 and this library currently does not use any functionality only available in .NET 6, it may make sense to change the target framework back in order to support a wider range of frameworks. See [this Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting) article for guidance.