### PR TITLE
test: use DynamicData for StandardPlayingCardTests

### DIFF
--- a/Xyaneon.Games.Cards.Test/StandardPlayingCardTests.cs
+++ b/Xyaneon.Games.Cards.Test/StandardPlayingCardTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xyaneon.Games.Cards.StandardPlayingCards;
 
@@ -17,21 +18,13 @@ namespace Xyaneon.Games.Cards.Test
         /// class.
         /// </summary>
         [TestMethod]
-        public void StandardPlayingCard_BasicInitializationTest()
+        [DynamicData(nameof(AllRanksAndSuitsData), DynamicDataSourceType.Method)]
+        public void StandardPlayingCard_BasicInitializationTest(Rank rank, Suit suit)
         {
-            // Arrange.
-            StandardPlayingCard card;
+            var card = new StandardPlayingCard(rank, suit);
 
-            // Act and assert.
-            foreach (Rank rank in Enum.GetValues(typeof(Rank)).Cast<Rank>())
-            {
-                foreach (Suit suit in Enum.GetValues(typeof(Suit)).Cast<Suit>())
-                {
-                    card = new StandardPlayingCard(rank, suit);
-                    Assert.AreEqual(rank, card.Rank);
-                    Assert.AreEqual(suit, card.Suit);
-                }
-            }
+            Assert.AreEqual(rank, card.Rank);
+            Assert.AreEqual(suit, card.Suit);
         }
 
         /// <summary>
@@ -39,22 +32,23 @@ namespace Xyaneon.Games.Cards.Test
         /// <see cref="StandardPlayingCard"/> class.
         /// </summary>
         [TestMethod]
-        public void StandardPlayingCard_EqualityTest()
+        [DynamicData(nameof(AllRanksAndSuitsData), DynamicDataSourceType.Method)]
+        public void StandardPlayingCard_EqualityTest(Rank rank, Suit suit)
         {
-            // Arrange.
-            StandardPlayingCard card1;
-            StandardPlayingCard card2;
+            var card1 = new StandardPlayingCard(rank, suit);
+            var card2 = new StandardPlayingCard(rank, suit);
 
-            // Act and assert.
+            Assert.IsFalse(ReferenceEquals(card1, card2));
+            Assert.IsTrue(card1 == card2);
+            Assert.IsFalse(card1 != card2);
+        }
+
+        public static IEnumerable<object[]> AllRanksAndSuitsData() {
             foreach (Rank rank in Enum.GetValues(typeof(Rank)).Cast<Rank>())
             {
                 foreach (Suit suit in Enum.GetValues(typeof(Suit)).Cast<Suit>())
                 {
-                    card1 = new StandardPlayingCard(rank, suit);
-                    card2 = new StandardPlayingCard(rank, suit);
-                    Assert.IsFalse(ReferenceEquals(card1, card2));
-                    Assert.IsTrue(card1 == card2);
-                    Assert.IsFalse(card1 != card2);
+                    yield return new object[] {rank, suit};
                 }
             }
         }


### PR DESCRIPTION
This converts some unit tests from using nested `foreach` loops to using `DynamicData`, so we could tell more easily which specific cases fail.