### PR TITLE
Ability to support card game types that involves multiple decks

### DIFF
--- a/Xyaneon.Games.Cards/StandardPlayingCards/StandardPlayingCard.cs
+++ b/Xyaneon.Games.Cards/StandardPlayingCards/StandardPlayingCard.cs
@@ -100,17 +100,6 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
             return Equals(obj as StandardPlayingCard);
         }
 
-        /// <summary>
-        /// Gets a hash code for this <see cref="StandardPlayingCard"/>.
-        /// </summary>
-        /// <returns>
-        /// A a hash code for the current <see cref="StandardPlayingCard"/>.
-        /// </returns>
-        public override int GetHashCode()
-        {
-            return Rank.GetHashCode() ^ Suit.GetHashCode();
-        }
-
         #endregion // End public methods region.
 
         #endregion // End methods region.

--- a/Xyaneon.Games.Cards/StandardPlayingCards/StandardPlayingCard.cs
+++ b/Xyaneon.Games.Cards/StandardPlayingCards/StandardPlayingCard.cs
@@ -12,7 +12,7 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
     /// <seealso cref="StandardPlayingCards.Rank"/>
     /// <seealso cref="StandardPlayingCards.Suit"/>
     /// <seealso cref="StandardPlayingCardDeck"/>
-    public class StandardPlayingCard : Card, IEquatable<StandardPlayingCard>
+    public class StandardPlayingCard : Card
     {
         #region Constructors
 
@@ -35,11 +35,9 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
 
         #endregion // End constructors region.
 
-        #region IEquatable<StandardPlayingCard> implementation
-
         /// <summary>
         /// Indicates whether the current <see cref="StandardPlayingCard"/>
-        /// is equal to another <see cref="StandardPlayingCard"/>.
+        /// is equal in value to another <see cref="StandardPlayingCard"/>.
         /// </summary>
         /// <param name="other">
         /// The <see cref="StandardPlayingCard"/> to compare with this
@@ -47,12 +45,11 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
         /// </param>
         /// <returns>
         /// <see langword="true"/> if the other
-        /// <see cref="StandardPlayingCard"/> is equal to this
+        /// <see cref="StandardPlayingCard"/> is equal in Rank and Suit to this
         /// <see cref="StandardPlayingCard"/>; otherwise,
         /// <see langword="false"/>.
         /// </returns>
-        /// <seealso cref="IEquatable{T}.Equals(T)"/>
-        public bool Equals(StandardPlayingCard other)
+        public bool ValueEquals(StandardPlayingCard other)
         {
             if (other == null)
             {
@@ -61,8 +58,6 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
 
             return Rank.Equals(other.Rank) && Suit.Equals(other.Suit);
         }
-
-        #endregion // End IEquatable<StandardPlayingCard> implementation region.
 
         #region Properties
 
@@ -77,89 +72,6 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
         public Suit Suit { get; }
 
         #endregion // End properties region.
-
-        #region Methods
-
-        #region Public methods
-
-        #endregion // End public methods region.
-
-        #endregion // End methods region.
-
-        #region Operators
-
-        /// <summary>
-        /// Determines whether two <see cref="StandardPlayingCard"/>
-        /// instances are equal to each other.
-        /// </summary>
-        /// <param name="card1">
-        /// The <see cref="StandardPlayingCard"/> on the left hand of the
-        /// expression.
-        /// </param>
-        /// <param name="card2">
-        /// The <see cref="StandardPlayingCard"/> on the right hand of the
-        /// expression.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if <paramref name="card1"/> is equal to
-        /// <paramref name="card2"/>; otherwise, <see langword="false"/>.
-        /// </returns>
-        public static bool operator ==(StandardPlayingCard card1, StandardPlayingCard card2)
-        {
-            if (ReferenceEquals(card1, card2))
-            {
-                return true;
-            }
-
-            if (card1 is null)
-            {
-                return false;
-            }
-
-            if (card2 is null)
-            {
-                return false;
-            }
-
-            return card1.Equals(card2);
-        }
-
-        /// <summary>
-        /// Determines whether two <see cref="StandardPlayingCard"/>
-        /// instances are not equal to each other.
-        /// </summary>
-        /// <param name="card1">
-        /// The <see cref="StandardPlayingCard"/> on the left hand of the
-        /// expression.
-        /// </param>
-        /// <param name="card2">
-        /// The <see cref="StandardPlayingCard"/> on the right hand of the
-        /// expression.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if <paramref name="card1"/> is not equal to
-        /// <paramref name="card2"/>; otherwise, <see langword="false"/>.
-        /// </returns>
-        public static bool operator !=(StandardPlayingCard card1, StandardPlayingCard card2)
-        {
-            if (ReferenceEquals(card1, card2))
-            {
-                return false;
-            }
-
-            if (card1 is null)
-            {
-                return true;
-            }
-
-            if (card2 is null)
-            {
-                return true;
-            }
-
-            return !card1.Equals(card2);
-        }
-
-        #endregion // End operators region.
+     
     }
 }

--- a/Xyaneon.Games.Cards/StandardPlayingCards/StandardPlayingCard.cs
+++ b/Xyaneon.Games.Cards/StandardPlayingCards/StandardPlayingCard.cs
@@ -82,24 +82,6 @@ namespace Xyaneon.Games.Cards.StandardPlayingCards
 
         #region Public methods
 
-        /// <summary>
-        /// Determines whether the specified object is equal to
-        /// this <see cref="StandardPlayingCard"/>.
-        /// </summary>
-        /// <param name="obj">
-        /// The object to compare to the current
-        /// <see cref="StandardPlayingCard"/>.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if the specified object is equal to
-        /// this <see cref="StandardPlayingCard"/>; otherwise,
-        /// <see langword="false"/>.
-        /// </returns>
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as StandardPlayingCard);
-        }
-
         #endregion // End public methods region.
 
         #endregion // End methods region.


### PR DESCRIPTION
Currently the StandardPlayingCard hashcode is generated based on the card's Rank and Suit, which will prevent multiple cards with the same suit and rank to exist in the game. There are several games that invovle multiple decks and so will have multiple of the same cards. Each card object should be unique in nature. Removing this override will allow for this.