### PR TITLE
feat: shift to shuffle algorithm as delegate

### DIFF
--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Xyaneon.Games.Cards.Test.Extensions;
 using Xyaneon.Games.Cards.Test.Helpers;
 
 namespace Xyaneon.Games.Cards.Test
@@ -38,7 +39,7 @@ namespace Xyaneon.Games.Cards.Test
             Assert.AreEqual(expectedFaceDown, faceDownDrawPile.IsFaceUp);
             foreach (var drawPile in new DrawPile<Card>[] { defaultDrawPile, faceUpDrawPile, faceDownDrawPile })
             {
-                Assert.IsTrue(drawPile.IsEmpty);
+                Assert.That.DrawPileIsEmpty(drawPile);
             }
         }
 
@@ -60,7 +61,7 @@ namespace Xyaneon.Games.Cards.Test
 
             // Assert.
             Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
-            Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
+            Assert.That.CardSetsAreEqual(expectedCardSet, actualCardSet);
         }
 
         /// <summary>
@@ -81,7 +82,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The shuffling algorithm to use cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The shuffling algorithm to use cannot be null.");
         }
 
         /// <summary>
@@ -107,7 +108,7 @@ namespace Xyaneon.Games.Cards.Test
             actualCardList = drawPile.Cards.ToList();
 
             // Assert.
-            CollectionAssert.AreEqual(expectedCardList, actualCardList);
+            Assert.That.CardListsAreEqual(expectedCardList, actualCardList);
         }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The draw pile to shuffle into this draw pile cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The draw pile to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -151,9 +152,9 @@ namespace Xyaneon.Games.Cards.Test
 
             // Assert.
             Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
-            Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
+            Assert.That.CardSetsAreEqual(expectedCardSet, actualCardSet);
             Assert.AreEqual(expectedCardSet.Count, drawPile1.Cards.Count);
-            Assert.AreEqual(0, drawPile2.Cards.Count);
+            Assert.That.DrawPileIsEmpty(drawPile2);
         }
 
         /// <summary>
@@ -178,7 +179,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The draw pile to shuffle into this draw pile cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The draw pile to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -200,7 +201,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The shuffling algorithm to use cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The shuffling algorithm to use cannot be null.");
         }
 
         /// <summary>
@@ -227,8 +228,8 @@ namespace Xyaneon.Games.Cards.Test
             var actualCardList = drawPile1.Cards.ToList();
 
             // Assert.
-            CollectionAssert.AreEqual(expectedCardList, actualCardList, $"Card lists differ.\nExpected: {FormatCardList(expectedCardList)}.\nActual  : {FormatCardList(actualCardList)}.\n");
-            Assert.AreEqual(0, drawPile2.Cards.Count);
+            Assert.That.CardListsAreEqual(expectedCardList, actualCardList);
+            Assert.That.DrawPileIsEmpty(drawPile2);
         }
 
         /// <summary>
@@ -248,7 +249,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The collection of cards to shuffle into this draw pile cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The collection of cards to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -271,7 +272,7 @@ namespace Xyaneon.Games.Cards.Test
 
             // Assert.
             Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
-            Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
+            Assert.That.CardSetsAreEqual(expectedCardSet, actualCardSet);
             Assert.AreEqual(expectedCardSet.Count, drawPile.Cards.Count);
         }
 
@@ -297,7 +298,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The collection of cards to shuffle into this draw pile cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The collection of cards to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -318,7 +319,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.IsTrue(actualException.Message.Contains("The shuffling algorithm to use cannot be null."));
+            Assert.That.StringContains(actualException.Message, "The shuffling algorithm to use cannot be null.");
         }
 
         /// <summary>
@@ -341,10 +342,10 @@ namespace Xyaneon.Games.Cards.Test
 
             // Act.
             drawPile.ShuffleIn(cards2, shuffleAlgorithm);
-            var actualCardList = drawPile.Cards.ToList();
+            var actualCardList = drawPile.Cards;
 
             // Assert.
-            CollectionAssert.AreEqual(expectedCardList, actualCardList, $"Card lists differ.\nExpected: {FormatCardList(expectedCardList)}.\nActual  : {FormatCardList(actualCardList)}.\n");
+            Assert.That.CardListsAreEqual(expectedCardList, actualCardList);
         }
 
         /// <summary>
@@ -366,9 +367,9 @@ namespace Xyaneon.Games.Cards.Test
 
             // Assert.
             Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
-            Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
-            Assert.IsTrue(expectedCardSet.SetEquals(new HashSet<IntCard>(drawnCards)));
-            Assert.AreEqual(0, drawPile.Cards.Count);
+            Assert.That.CardSetsAreEqual(expectedCardSet, actualCardSet);
+            Assert.That.CardSetsAreEqual(expectedCardSet, new HashSet<IntCard>(drawnCards));
+            Assert.That.DrawPileIsEmpty(drawPile);
         }
 
         /// <summary>
@@ -403,11 +404,6 @@ namespace Xyaneon.Games.Cards.Test
             {
                 return a.Value - b.Value;
             }));
-        }
-
-        private static string FormatCardList(IEnumerable<IntCard> cards)
-        {
-            return "[" + string.Join(", ", cards) + "]";
         }
     }
 }

--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -111,6 +111,46 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard})"/>
+        /// method rejects a null <see cref="DrawPile{TCard}"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInDrawPileShouldRejectNullDrawPileTest()
+        {
+            // Arrange.
+            var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var drawPile = new DrawPile<IntCard>(cards);
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile.ShuffleIn((IDrawPile<IntCard>)null);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The draw pile to shuffle into this draw pile cannot be null."));
+        }
+
+        /// <summary>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard})"/>
+        /// method rejects a null <see cref="IEnumerable{TCard}"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInEnumerableShouldRejectNullEnumerableTest()
+        {
+            // Arrange.
+            var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var drawPile = new DrawPile<IntCard>(cards);
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile.ShuffleIn((IEnumerable<IntCard>)null);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The collection of cards to shuffle into this draw pile cannot be null."));
+        }
+
+        /// <summary>
         /// Tests the <see cref="DrawPile{TCard}.DrawAll"/> method.
         /// </summary>
         [TestMethod]

--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -82,7 +82,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The shuffling algorithm to use cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The shuffling algorithm to use cannot be null.");
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The draw pile to shuffle into this draw pile cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The draw pile to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The draw pile to shuffle into this draw pile cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The draw pile to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The shuffling algorithm to use cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The shuffling algorithm to use cannot be null.");
         }
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The collection of cards to shuffle into this draw pile cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The collection of cards to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The collection of cards to shuffle into this draw pile cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The collection of cards to shuffle into this draw pile cannot be null.");
         }
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace Xyaneon.Games.Cards.Test
             });
 
             // Assert.
-            Assert.That.StringContains(actualException.Message, "The shuffling algorithm to use cannot be null.");
+            Assert.That.ExceptionMessageStartsWith(actualException, "The shuffling algorithm to use cannot be null.");
         }
 
         /// <summary>

--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -131,6 +131,32 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
+        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard})"/>
+        /// functionality with a valid <see cref="DrawPile{TCard}"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInDrawPileTest()
+        {
+            // Arrange.
+            var cards1 = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var cards2 = new IntCard[] { new IntCard(4), new IntCard(5) };
+            var drawPile1 = new DrawPile<IntCard>(cards1);
+            var drawPile2 = new DrawPile<IntCard>(cards2);
+            HashSet<IntCard> actualCardSet;
+            var expectedCardSet = cards1.Concat(cards2).ToHashSet();
+
+            // Act.
+            drawPile1.ShuffleIn(drawPile2);
+            actualCardSet = drawPile1.Cards.ToHashSet();
+
+            // Assert.
+            Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
+            Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
+            Assert.AreEqual(expectedCardSet.Count, drawPile1.Cards.Count);
+            Assert.AreEqual(0, drawPile2.Cards.Count);
+        }
+
+        /// <summary>
         /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard})"/>
         /// method rejects a null <see cref="IEnumerable{TCard}"/> argument.
         /// </summary>
@@ -148,6 +174,30 @@ namespace Xyaneon.Games.Cards.Test
 
             // Assert.
             Assert.IsTrue(actualException.Message.Contains("The collection of cards to shuffle into this draw pile cannot be null."));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard})"/>
+        /// functionality with a valid <see cref="IEnumerable{TCard}"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInEnumerableTest()
+        {
+            // Arrange.
+            var cards1 = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var cards2 = new IntCard[] { new IntCard(4), new IntCard(5) };
+            var drawPile = new DrawPile<IntCard>(cards1);
+            HashSet<IntCard> actualCardSet;
+            var expectedCardSet = cards1.Concat(cards2).ToHashSet();
+
+            // Act.
+            drawPile.ShuffleIn(cards2);
+            actualCardSet = drawPile.Cards.ToHashSet();
+
+            // Assert.
+            Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
+            Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
+            Assert.AreEqual(expectedCardSet.Count, drawPile.Cards.Count);
         }
 
         /// <summary>

--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -74,11 +74,10 @@ namespace Xyaneon.Games.Cards.Test
             // Arrange.
             var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
             var drawPile = new DrawPile<IntCard>(cards);
-            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm = null;
 
             // Act.
             var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
-                drawPile.Shuffle(shuffleAlgorithm);
+                drawPile.Shuffle((ShuffleFunction<IntCard>)null);
             });
 
             // Assert.
@@ -99,8 +98,7 @@ namespace Xyaneon.Games.Cards.Test
             // For the custom shuffling algorithm, simply reverse the existing
             // card order as a predictable way of determining the shuffling was
             // done correctly in a unit testing context.
-            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
-                cards => cards.Reverse().ToList();
+            ShuffleFunction<IntCard> shuffleAlgorithm = cards => cards.Reverse().ToList();
             var expectedCardList = cards.Reverse().ToList();
 
             // Act.
@@ -158,7 +156,7 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
-        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, ShuffleFunction{TCard})"/>
         /// method rejects a null <see cref="DrawPile{TCard}"/> argument.
         /// </summary>
         [TestMethod]
@@ -170,8 +168,7 @@ namespace Xyaneon.Games.Cards.Test
             // For the custom shuffling algorithm, simply reverse the existing
             // card order as a predictable way of determining the shuffling was
             // done correctly in a unit testing context.
-            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
-                cards => cards.Reverse().ToList();
+            ShuffleFunction<IntCard> shuffleAlgorithm = cards => cards.Reverse().ToList();
 
             // Act.
             var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
@@ -183,8 +180,8 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
-        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
-        /// method rejects a null <see cref="Func{IEnumerable{TCard}, IList{TCard}})"/> argument.
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, ShuffleFunction{TCard})"/>
+        /// method rejects a null <see cref="ShuffleFunction{TCard})"/> argument.
         /// </summary>
         [TestMethod]
         public void DrawPile_ShuffleInCustomDrawPileShouldRejectNullAlgorithmTest()
@@ -197,7 +194,7 @@ namespace Xyaneon.Games.Cards.Test
 
             // Act.
             var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
-                drawPile1.ShuffleIn(drawPile2, (Func<IEnumerable<IntCard>, IList<IntCard>>)null);
+                drawPile1.ShuffleIn(drawPile2, (ShuffleFunction<IntCard>)null);
             });
 
             // Assert.
@@ -205,7 +202,7 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
-        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, ShuffleFunction{TCard})"/>
         /// functionality with valid arguments.
         /// </summary>
         [TestMethod]
@@ -219,8 +216,7 @@ namespace Xyaneon.Games.Cards.Test
             // For the custom shuffling algorithm, simply reverse the existing
             // card order as a predictable way of determining the shuffling was
             // done correctly in a unit testing context.
-            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
-                cards => cards.Reverse().ToList();
+            ShuffleFunction<IntCard> shuffleAlgorithm = cards => cards.Reverse().ToList();
             var expectedCardList = cards2.Concat(cards1).Reverse().ToList();
 
             // Act.
@@ -277,7 +273,7 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
-        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, ShuffleFunction{TCard})"/>
         /// method rejects a null <see cref="IEnumerable{TCard}"/> argument.
         /// </summary>
         [TestMethod]
@@ -289,8 +285,7 @@ namespace Xyaneon.Games.Cards.Test
             // For the custom shuffling algorithm, simply reverse the existing
             // card order as a predictable way of determining the shuffling was
             // done correctly in a unit testing context.
-            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
-                cards => cards.Reverse().ToList();
+            ShuffleFunction<IntCard> shuffleAlgorithm = cards => cards.Reverse().ToList();
 
             // Act.
             var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
@@ -302,8 +297,8 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
-        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
-        /// method rejects a null <see cref="Func{IEnumerable{TCard}, IList{TCard}})"/> argument.
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, ShuffleFunction{TCard})"/>
+        /// method rejects a null <see cref="ShuffleFunction{TCard})"/> argument.
         /// </summary>
         [TestMethod]
         public void DrawPile_ShuffleInCustomEnumerableShouldRejectNullAlgorithmTest()
@@ -315,7 +310,7 @@ namespace Xyaneon.Games.Cards.Test
 
             // Act.
             var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
-                drawPile.ShuffleIn(cards2, (Func<IEnumerable<IntCard>, IList<IntCard>>)null);
+                drawPile.ShuffleIn(cards2, (ShuffleFunction<IntCard>)null);
             });
 
             // Assert.
@@ -323,7 +318,7 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
-        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, ShuffleFunction{TCard})"/>
         /// functionality with valid arguments.
         /// </summary>
         [TestMethod]
@@ -336,8 +331,7 @@ namespace Xyaneon.Games.Cards.Test
             // For the custom shuffling algorithm, simply reverse the existing
             // card order as a predictable way of determining the shuffling was
             // done correctly in a unit testing context.
-            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
-                cards => cards.Reverse().ToList();
+            ShuffleFunction<IntCard> shuffleAlgorithm = cards => cards.Reverse().ToList();
             var expectedCardList = cards2.Reverse().Concat(cards1).Reverse().ToList();
 
             // Act.

--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -157,6 +157,81 @@ namespace Xyaneon.Games.Cards.Test
         }
 
         /// <summary>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// method rejects a null <see cref="DrawPile{TCard}"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInCustomDrawPileShouldRejectNullDrawPileTest()
+        {
+            // Arrange.
+            var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var drawPile = new DrawPile<IntCard>(cards);
+            // For the custom shuffling algorithm, simply reverse the existing
+            // card order as a predictable way of determining the shuffling was
+            // done correctly in a unit testing context.
+            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
+                cards => cards.Reverse().ToList();
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile.ShuffleIn((IDrawPile<IntCard>)null, shuffleAlgorithm);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The draw pile to shuffle into this draw pile cannot be null."));
+        }
+
+        /// <summary>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// method rejects a null <see cref="Func{IEnumerable{TCard}, IList{TCard}})"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInCustomDrawPileShouldRejectNullAlgorithmTest()
+        {
+            // Arrange.
+            var cards1 = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var cards2 = new IntCard[] { new IntCard(4), new IntCard(5) };
+            var drawPile1 = new DrawPile<IntCard>(cards1);
+            var drawPile2 = new DrawPile<IntCard>(cards2);
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile1.ShuffleIn(drawPile2, (Func<IEnumerable<IntCard>, IList<IntCard>>)null);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The shuffling algorithm to use cannot be null."));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IDrawPile{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// functionality with valid arguments.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInCustomDrawPileTest()
+        {
+            // Arrange.
+            var cards1 = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var cards2 = new IntCard[] { new IntCard(4), new IntCard(5) };
+            var drawPile1 = new DrawPile<IntCard>(cards1);
+            var drawPile2 = new DrawPile<IntCard>(cards2);
+            // For the custom shuffling algorithm, simply reverse the existing
+            // card order as a predictable way of determining the shuffling was
+            // done correctly in a unit testing context.
+            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
+                cards => cards.Reverse().ToList();
+            var expectedCardList = cards2.Concat(cards1).Reverse().ToList();
+
+            // Act.
+            drawPile1.ShuffleIn(drawPile2, shuffleAlgorithm);
+            var actualCardList = drawPile1.Cards.ToList();
+
+            // Assert.
+            CollectionAssert.AreEqual(expectedCardList, actualCardList, $"Card lists differ.\nExpected: {FormatCardList(expectedCardList)}.\nActual  : {FormatCardList(actualCardList)}.\n");
+            Assert.AreEqual(0, drawPile2.Cards.Count);
+        }
+
+        /// <summary>
         /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard})"/>
         /// method rejects a null <see cref="IEnumerable{TCard}"/> argument.
         /// </summary>
@@ -198,6 +273,78 @@ namespace Xyaneon.Games.Cards.Test
             Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
             Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
             Assert.AreEqual(expectedCardSet.Count, drawPile.Cards.Count);
+        }
+
+        /// <summary>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// method rejects a null <see cref="IEnumerable{TCard}"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInCustomEnumerableShouldRejectNullEnumerableTest()
+        {
+            // Arrange.
+            var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var drawPile = new DrawPile<IntCard>(cards);
+            // For the custom shuffling algorithm, simply reverse the existing
+            // card order as a predictable way of determining the shuffling was
+            // done correctly in a unit testing context.
+            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
+                cards => cards.Reverse().ToList();
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile.ShuffleIn((IEnumerable<IntCard>)null, shuffleAlgorithm);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The collection of cards to shuffle into this draw pile cannot be null."));
+        }
+
+        /// <summary>
+        /// Ensures the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// method rejects a null <see cref="Func{IEnumerable{TCard}, IList{TCard}})"/> argument.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInCustomEnumerableShouldRejectNullAlgorithmTest()
+        {
+            // Arrange.
+            var cards1 = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var cards2 = new IntCard[] { new IntCard(4), new IntCard(5) };
+            var drawPile = new DrawPile<IntCard>(cards1);
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile.ShuffleIn(cards2, (Func<IEnumerable<IntCard>, IList<IntCard>>)null);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The shuffling algorithm to use cannot be null."));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="DrawPile{TCard}.ShuffleIn(IEnumerable{TCard}, Func{IEnumerable{TCard}, IList{TCard}})"/>
+        /// functionality with valid arguments.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_ShuffleInCustomEnumerableTest()
+        {
+            // Arrange.
+            var cards1 = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var cards2 = new IntCard[] { new IntCard(4), new IntCard(5) };
+            var drawPile = new DrawPile<IntCard>(cards1);
+            // For the custom shuffling algorithm, simply reverse the existing
+            // card order as a predictable way of determining the shuffling was
+            // done correctly in a unit testing context.
+            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
+                cards => cards.Reverse().ToList();
+            var expectedCardList = cards2.Reverse().Concat(cards1).Reverse().ToList();
+
+            // Act.
+            drawPile.ShuffleIn(cards2, shuffleAlgorithm);
+            var actualCardList = drawPile.Cards.ToList();
+
+            // Assert.
+            CollectionAssert.AreEqual(expectedCardList, actualCardList, $"Card lists differ.\nExpected: {FormatCardList(expectedCardList)}.\nActual  : {FormatCardList(actualCardList)}.\n");
         }
 
         /// <summary>
@@ -256,6 +403,11 @@ namespace Xyaneon.Games.Cards.Test
             {
                 return a.Value - b.Value;
             }));
+        }
+
+        private static string FormatCardList(IEnumerable<IntCard> cards)
+        {
+            return "[" + string.Join(", ", cards) + "]";
         }
     }
 }

--- a/Xyaneon.Games.Cards.Test/DrawPileTests.cs
+++ b/Xyaneon.Games.Cards.Test/DrawPileTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xyaneon.Games.Cards.Test.Helpers;
 
 namespace Xyaneon.Games.Cards.Test
@@ -59,6 +61,53 @@ namespace Xyaneon.Games.Cards.Test
             // Assert.
             Assert.AreEqual(expectedCardSet.Count, actualCardSet.Count);
             Assert.IsTrue(expectedCardSet.SetEquals(actualCardSet));
+        }
+
+        /// <summary>
+        /// Ensures custom shuffling of the <see cref="DrawPile{TCard}"/> class
+        /// will not accept a null delegate.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_CustomShuffleAlgorithmShouldRejectNullTest()
+        {
+            // Arrange.
+            var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var drawPile = new DrawPile<IntCard>(cards);
+            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm = null;
+
+            // Act.
+            var actualException = Assert.ThrowsException<ArgumentNullException>(() => {
+                drawPile.Shuffle(shuffleAlgorithm);
+            });
+
+            // Assert.
+            Assert.IsTrue(actualException.Message.Contains("The shuffling algorithm to use cannot be null."));
+        }
+
+        /// <summary>
+        /// Tests custom shuffling of the <see cref="DrawPile{TCard}"/> class.
+        /// </summary>
+        [TestMethod]
+        public void DrawPile_CustomShuffleAlgorithmTest()
+        {
+            // Arrange.
+            var cards = new IntCard[] { new IntCard(1), new IntCard(2), new IntCard(3) };
+            var expectedCardSet = new HashSet<IntCard>(cards);
+            List<IntCard> actualCardList;
+            var drawPile = new DrawPile<IntCard>(cards);
+            // For the custom shuffling algorithm, simply reverse the existing
+            // card order as a predictable way of determining the shuffling was
+            // done correctly in a unit testing context.
+            Func<IEnumerable<IntCard>, IList<IntCard>> shuffleAlgorithm =
+                cards => cards.Reverse().ToList();
+            var expectedCardList = cards.Reverse().ToList();
+
+            // Act.
+            drawPile.Shuffle(shuffleAlgorithm);
+            actualCardList = drawPile.Cards.ToList();
+
+            // Assert.
+            CollectionAssert.AreEqual(expectedCardList, actualCardList);
         }
 
         /// <summary>

--- a/Xyaneon.Games.Cards.Test/Extensions/AssertExtensions.cs
+++ b/Xyaneon.Games.Cards.Test/Extensions/AssertExtensions.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Xyaneon.Games.Cards.Test.Extensions
+{
+    public static class AssertExtensions
+    {
+        public static void CardListsAreEqual<TCard>(this Assert assert, IEnumerable<TCard> expectedCardList, IEnumerable<TCard> actualCardList) where TCard : Card
+        {
+            if (expectedCardList.SequenceEqual(actualCardList))
+            {
+                return;
+            }
+
+            throw new AssertFailedException(CreateUnequalCardListsMessage(expectedCardList, actualCardList));
+        }
+
+        public static void CardSetsAreEqual<TCard>(this Assert assert, ISet<TCard> expectedCardList, ISet<TCard> actualCardList) where TCard : Card
+        {
+            if (expectedCardList.SetEquals(actualCardList))
+            {
+                return;
+            }
+
+            throw new AssertFailedException(CreateUnequalCardSetsMessage(expectedCardList, actualCardList));
+        }
+
+        public static void DrawPileIsEmpty<TCard>(this Assert assert, IDrawPile<TCard> drawPile) where TCard : Card
+        {
+            if (drawPile.IsEmpty)
+            {
+                return;
+            }
+
+            throw new AssertFailedException($"The draw pile was expected to be empty, but contained {drawPile.Cards.Count} card(s).");
+        }
+
+        public static void StringContains(this Assert assert, string actualString, string expectedSubstring)
+        {
+            if (actualString.Contains(expectedSubstring))
+            {
+                return;
+            }
+
+            throw new AssertFailedException(CreateSubstringNotFoundMessage(expectedSubstring, actualString));
+        }
+
+        private static string CreateSubstringNotFoundMessage(string expectedSubstring, string actualString)
+        {
+            return (new StringBuilder())
+                .AppendLine("Substring not found.")
+                .Append("Expected: ")
+                .AppendLine($"\"{expectedSubstring}\"")
+                .Append("Actual  : ")
+                .AppendLine($"\"{actualString}\"")
+                .ToString();
+        }
+
+        private static string CreateUnequalCardListsMessage<TCard>(IEnumerable<TCard> expectedCardList, IEnumerable<TCard> actualCardList) where TCard : Card
+        {
+            return (new StringBuilder())
+                .AppendLine("Card lists differ.")
+                .Append("Expected: ")
+                .AppendLine(FormatCardList(expectedCardList))
+                .Append("Actual  : ")
+                .AppendLine(FormatCardList(actualCardList))
+                .ToString();
+        }
+
+        private static string CreateUnequalCardSetsMessage<TCard>(IEnumerable<TCard> expectedCardList, IEnumerable<TCard> actualCardList) where TCard : Card
+        {
+            return (new StringBuilder())
+                .AppendLine("Card sets differ.")
+                .Append("Expected: ")
+                .AppendLine(FormatCardList(expectedCardList))
+                .Append("Actual  : ")
+                .AppendLine(FormatCardList(actualCardList))
+                .ToString();
+        }
+
+        private static string FormatCardList<TCard>(IEnumerable<TCard> cards) where TCard : Card
+        {
+            return "[" + string.Join(", ", cards) + "]";
+        }
+    }
+}

--- a/Xyaneon.Games.Cards.Test/Extensions/AssertExtensions.cs
+++ b/Xyaneon.Games.Cards.Test/Extensions/AssertExtensions.cs
@@ -38,24 +38,24 @@ namespace Xyaneon.Games.Cards.Test.Extensions
             throw new AssertFailedException($"The draw pile was expected to be empty, but contained {drawPile.Cards.Count} card(s).");
         }
 
-        public static void StringContains(this Assert assert, string actualString, string expectedSubstring)
+        public static void ExceptionMessageStartsWith(this Assert assert, Exception actualException, string expected)
         {
-            if (actualString.Contains(expectedSubstring))
+            if (actualException.Message.StartsWith(expected))
             {
                 return;
             }
 
-            throw new AssertFailedException(CreateSubstringNotFoundMessage(expectedSubstring, actualString));
+            throw new AssertFailedException(CreateExceptionMessageDidNotStartWithMessage(actualException, expected));
         }
 
-        private static string CreateSubstringNotFoundMessage(string expectedSubstring, string actualString)
+        private static string CreateExceptionMessageDidNotStartWithMessage(Exception actualException, string expectedSubstring)
         {
             return (new StringBuilder())
-                .AppendLine("Substring not found.")
+                .AppendLine("Exception message did not start with expected substring.")
                 .Append("Expected: ")
                 .AppendLine($"\"{expectedSubstring}\"")
                 .Append("Actual  : ")
-                .AppendLine($"\"{actualString}\"")
+                .AppendLine($"\"{actualException.Message}\"")
                 .ToString();
         }
 

--- a/Xyaneon.Games.Cards.Test/Helpers/IntCard.cs
+++ b/Xyaneon.Games.Cards.Test/Helpers/IntCard.cs
@@ -29,5 +29,7 @@
         public int Value { get; }
 
         #endregion // End properties region.
+
+        public override string ToString() => Value.ToString();
     }
 }

--- a/Xyaneon.Games.Cards/DefaultShuffleAlgorithm.cs
+++ b/Xyaneon.Games.Cards/DefaultShuffleAlgorithm.cs
@@ -10,6 +10,14 @@ namespace Xyaneon.Games.Cards
     /// <typeparam name="TCard">
     /// The <see cref="Type"/> of cards this algorithm will be used to shuffle.
     /// </typeparam>
+    /// <remarks>
+    /// This class is deprecated, along with the
+    /// <see cref="IShuffleAlgorithm{TCard}"/> interface itself. Instead, you
+    /// should call the shuffling methods on <see cref="DrawPile{TCard}"/>
+    /// that do not need a shuffling algorithm supplied to get the same
+    /// default shuffling behavior.
+    /// </remarks>
+    [Obsolete("This class is deprecated along with the IShuffleAlgorithm interface. Instead, use DrawPile<TCard> shuffling methods without specifying a shuffling algorithm.")]
     public sealed class DefaultShuffleAlgorithm<TCard> : IShuffleAlgorithm<TCard> where TCard : Card
     {
         #region IShuffleAlgorithm<TCard> implementation

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -401,6 +401,44 @@ namespace Xyaneon.Games.Cards
         }
 
         /// <summary>
+        /// Shuffles the provided draw pile into this
+        /// <see cref="DrawPile{TCard}"/> using the supplied shuffling
+        /// algorithm.
+        /// </summary>
+        /// <param name="other">
+        /// The <see cref="IDrawPile{TCard}"/> to shuffle into this
+        /// <see cref="DrawPile{TCard}"/>.
+        /// </param>
+        /// <param name="shuffleAlgorithm">
+        /// The delegate providing the shuffling algorithm to use.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="other"/> is <see langword="null"/>.
+        /// -or-
+        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="other"/> will be emptied of all of its cards as a
+        /// result of calling this algorithm.
+        /// </para>
+        /// </remarks>
+        public void ShuffleIn(IDrawPile<TCard> other, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other), "The draw pile to shuffle into this draw pile cannot be null.");
+            }
+
+            if (shuffleAlgorithm == null)
+            {
+                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
+            }
+
+            ShuffleInBase(other, shuffleAlgorithm);
+        }
+
+        /// <summary>
         /// Shuffles the provided <paramref name="cards"/> into this
         /// <see cref="DrawPile{TCard}"/> using a default shuffling algorithm.
         /// </summary>
@@ -445,6 +483,38 @@ namespace Xyaneon.Games.Cards
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
         public void ShuffleIn(IEnumerable<TCard> cards, IShuffleAlgorithm<TCard> shuffleAlgorithm)
+        {
+            if (cards == null)
+            {
+                throw new ArgumentNullException(nameof(cards), "The collection of cards to shuffle into this draw pile cannot be null.");
+            }
+
+            if (shuffleAlgorithm == null)
+            {
+                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
+            }
+
+            ShuffleInBase(cards, shuffleAlgorithm);
+        }
+
+        /// <summary>
+        /// Shuffles the provided <paramref name="cards"/> into this
+        /// <see cref="DrawPile{TCard}"/> using the supplied shuffling
+        /// algorithm.
+        /// </summary>
+        /// <param name="cards">
+        /// The collection of cards to shuffle into this
+        /// <see cref="DrawPile{TCard}"/>.
+        /// </param>
+        /// <param name="shuffleAlgorithm">
+        /// The delegate providing the shuffling algorithm to use.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="cards"/> is <see langword="null"/>.
+        /// -or-
+        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
+        /// </exception>
+        public void ShuffleIn(IEnumerable<TCard> cards, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
         {
             if (cards == null)
             {

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -310,6 +310,26 @@ namespace Xyaneon.Games.Cards
         }
 
         /// <summary>
+        /// Shuffles all of the cards in this <see cref="DrawPile{TCard}"/>
+        /// using the supplied shuffling algorithm.
+        /// </summary>
+        /// <param name="shuffleAlgorithm">
+        /// The delegate providing the shuffling algorithm to use.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
+        /// </exception>
+        public void Shuffle(Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            if (shuffleAlgorithm == null)
+            {
+                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
+            }
+
+            ShuffleBase(shuffleAlgorithm);
+        }
+
+        /// <summary>
         /// Shuffles the provided draw pile into this
         /// <see cref="DrawPile{TCard}"/> using a default shuffling algorithm.
         /// </summary>

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -276,18 +276,17 @@ namespace Xyaneon.Games.Cards
         }
 
         /// <summary>
-        /// Shuffles all of the cards in this <see cref="DrawPile{TCard}"/>
-        /// using a default shuffling algorithm.
+        /// Shuffles all of the cards in this <see cref="DrawPile{TCard}"/>.
         /// </summary>
         /// <remarks>
-        /// This method will use the shuffling algorithm provided by the
-        /// <see cref="DefaultShuffleAlgorithm{TCard}"/>. If you want to use
-        /// a custom shuffling method instead, then consider using the
-        /// <see cref="Shuffle(IShuffleAlgorithm{TCard})"/> overload method.
+        /// This method will use a default shuffling algorithm.
+        /// If you want to use a custom shuffling method instead, then
+        /// consider using the <see cref="Shuffle(IShuffleAlgorithm{TCard})"/>
+        /// overload method.
         /// </remarks>
         public void Shuffle()
         {
-            ShuffleBase(new DefaultShuffleAlgorithm<TCard>());
+            ShuffleBase(DefaultShuffleAlgorithm);
         }
 
         /// <summary>
@@ -459,6 +458,12 @@ namespace Xyaneon.Games.Cards
 
         #region Private methods
 
+        private static IList<TCard> DefaultShuffleAlgorithm(IEnumerable<TCard> cards)
+        {
+            var random = new Random();
+            return cards.OrderBy(c => random.Next()).ToList();
+        }
+
         /// <summary>
         /// The base method for shuffling the cards stored in this object.
         /// The <paramref name="shuffleAlgorithm"/> must always be specified.
@@ -483,6 +488,12 @@ namespace Xyaneon.Games.Cards
         private void ShuffleBase(IShuffleAlgorithm<TCard> shuffleAlgorithm)
         {
             IList<TCard> shuffledCards = shuffleAlgorithm.Shuffle(_cards);
+            _cards = new Stack<TCard>(shuffledCards);
+        }
+
+        private void ShuffleBase(Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            IList<TCard> shuffledCards = shuffleAlgorithm(_cards);
             _cards = new Stack<TCard>(shuffledCards);
         }
 

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -300,6 +300,13 @@ namespace Xyaneon.Games.Cards
         /// <exception cref="ArgumentNullException">
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        /// This interface method is deprecated, along with all others using
+        /// <see cref="IShuffleAlgorithm{TCard}"/>. Instead, you should use
+        /// the <see cref="Shuffle(ShuffleFunction{TCard})"/> method.
+        /// </remarks>
+        /// <seealso cref="Shuffle(ShuffleFunction{TCard})"/>
+        [Obsolete("IShuffleAlgorithm interface methods are deprecated. Use Shuffle(ShuffleFunction<TCard>) instead.")]
         public void Shuffle(IShuffleAlgorithm<TCard> shuffleAlgorithm)
         {
             if (shuffleAlgorithm == null)
@@ -365,7 +372,15 @@ namespace Xyaneon.Games.Cards
         /// <paramref name="other"/> will be emptied of all of its cards as a
         /// result of calling this algorithm.
         /// </para>
+        /// <para>
+        /// This interface method is deprecated, along with all others using
+        /// <see cref="IShuffleAlgorithm{TCard}"/>. Instead, you should use
+        /// the <see cref="ShuffleIn(IDrawPile{TCard}, ShuffleFunction{TCard})"/>
+        /// method.
+        /// </para>
         /// </remarks>
+        /// <seealso cref="ShuffleIn(IDrawPile{TCard}, ShuffleFunction{TCard})"/>
+        [Obsolete("IShuffleAlgorithm interface methods are deprecated. Use ShuffleIn(IDrawPile<TCard>, ShuffleFunction<TCard>) instead.")]
         public void ShuffleIn(IDrawPile<TCard> other, IShuffleAlgorithm<TCard> shuffleAlgorithm)
         {
             if (other == null)
@@ -425,6 +440,14 @@ namespace Xyaneon.Games.Cards
         /// -or-
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        /// This interface method is deprecated, along with all others using
+        /// <see cref="IShuffleAlgorithm{TCard}"/>. Instead, you should use
+        /// the <see cref="ShuffleIn(IEnumerable{TCard}, ShuffleFunction{TCard})"/>
+        /// method.
+        /// </remarks>
+        /// <seealso cref="ShuffleIn(IEnumerable{TCard}, ShuffleFunction{TCard})"/>
+        [Obsolete("IShuffleAlgorithm interface methods are deprecated. Use ShuffleIn(IEnumerable<TCard>, ShuffleFunction<TCard>) instead.")]
         public void ShuffleIn(IEnumerable<TCard> cards, IShuffleAlgorithm<TCard> shuffleAlgorithm)
         {
             if (cards == null)

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -601,7 +601,9 @@ namespace Xyaneon.Games.Cards
         /// supplied when needed.
         /// </para>
         /// </remarks>
+        #pragma warning disable 618
         private void ShuffleBase(IShuffleAlgorithm<TCard> shuffleAlgorithm)
+        #pragma warning restore 618
         {
             IList<TCard> shuffledCards = shuffleAlgorithm.Shuffle(_cards);
             _cards = new Stack<TCard>(shuffledCards);
@@ -642,7 +644,9 @@ namespace Xyaneon.Games.Cards
         /// result of calling this algorithm.
         /// </para>
         /// </remarks>
+        #pragma warning disable 618
         private void ShuffleInBase(IDrawPile<TCard> other, IShuffleAlgorithm<TCard> shuffleAlgorithm)
+        #pragma warning restore 618
         {
             IEnumerable<TCard> cardsToShuffle = _cards.Concat(other.DrawAll());
             IList<TCard> shuffledCards = shuffleAlgorithm.Shuffle(cardsToShuffle);
@@ -681,7 +685,9 @@ namespace Xyaneon.Games.Cards
         /// supplied when needed.
         /// </para>
         /// </remarks>
+        #pragma warning disable 618
         private void ShuffleInBase(IEnumerable<TCard> cards, IShuffleAlgorithm<TCard> shuffleAlgorithm)
+        #pragma warning restore 618
         {
             IEnumerable<TCard> cardsToShuffle = _cards.Concat(cards);
             IList<TCard> shuffledCards = shuffleAlgorithm.Shuffle(cardsToShuffle);

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -310,26 +310,6 @@ namespace Xyaneon.Games.Cards
         }
 
         /// <summary>
-        /// Shuffles all of the cards in this <see cref="DrawPile{TCard}"/>
-        /// using the supplied shuffling algorithm.
-        /// </summary>
-        /// <param name="shuffleAlgorithm">
-        /// The delegate providing the shuffling algorithm to use.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
-        /// </exception>
-        public void Shuffle(Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
-        {
-            if (shuffleAlgorithm == null)
-            {
-                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
-            }
-
-            ShuffleBase(shuffleAlgorithm);
-        }
-
-        /// <summary>
         /// Shuffles the provided draw pile into this
         /// <see cref="DrawPile{TCard}"/> using a default shuffling algorithm.
         /// </summary>
@@ -386,44 +366,6 @@ namespace Xyaneon.Games.Cards
         /// </para>
         /// </remarks>
         public void ShuffleIn(IDrawPile<TCard> other, IShuffleAlgorithm<TCard> shuffleAlgorithm)
-        {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other), "The draw pile to shuffle into this draw pile cannot be null.");
-            }
-
-            if (shuffleAlgorithm == null)
-            {
-                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
-            }
-
-            ShuffleInBase(other, shuffleAlgorithm);
-        }
-
-        /// <summary>
-        /// Shuffles the provided draw pile into this
-        /// <see cref="DrawPile{TCard}"/> using the supplied shuffling
-        /// algorithm.
-        /// </summary>
-        /// <param name="other">
-        /// The <see cref="IDrawPile{TCard}"/> to shuffle into this
-        /// <see cref="DrawPile{TCard}"/>.
-        /// </param>
-        /// <param name="shuffleAlgorithm">
-        /// The delegate providing the shuffling algorithm to use.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="other"/> is <see langword="null"/>.
-        /// -or-
-        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// <paramref name="other"/> will be emptied of all of its cards as a
-        /// result of calling this algorithm.
-        /// </para>
-        /// </remarks>
-        public void ShuffleIn(IDrawPile<TCard> other, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
         {
             if (other == null)
             {
@@ -497,6 +439,81 @@ namespace Xyaneon.Games.Cards
             ShuffleInBase(cards, shuffleAlgorithm);
         }
 
+        #endregion // End methods region.
+
+        #endregion // End IDrawPile<TCard> implementation region.
+
+        #region Fields
+
+        /// <summary>
+        /// Private backing field for the <see cref="Cards"/> property.
+        /// </summary>
+        private Stack<TCard> _cards;
+
+        #endregion // End fields region.
+
+        #region Methods
+
+        #region Public methods
+
+        /// <summary>
+        /// Shuffles all of the cards in this <see cref="DrawPile{TCard}"/>
+        /// using the supplied shuffling algorithm.
+        /// </summary>
+        /// <param name="shuffleAlgorithm">
+        /// The delegate providing the shuffling algorithm to use.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
+        /// </exception>
+        public void Shuffle(Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            if (shuffleAlgorithm == null)
+            {
+                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
+            }
+
+            ShuffleBase(shuffleAlgorithm);
+        }
+
+        /// <summary>
+        /// Shuffles the provided draw pile into this
+        /// <see cref="DrawPile{TCard}"/> using the supplied shuffling
+        /// algorithm.
+        /// </summary>
+        /// <param name="other">
+        /// The <see cref="IDrawPile{TCard}"/> to shuffle into this
+        /// <see cref="DrawPile{TCard}"/>.
+        /// </param>
+        /// <param name="shuffleAlgorithm">
+        /// The delegate providing the shuffling algorithm to use.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="other"/> is <see langword="null"/>.
+        /// -or-
+        /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="other"/> will be emptied of all of its cards as a
+        /// result of calling this algorithm.
+        /// </para>
+        /// </remarks>
+        public void ShuffleIn(IDrawPile<TCard> other, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other), "The draw pile to shuffle into this draw pile cannot be null.");
+            }
+
+            if (shuffleAlgorithm == null)
+            {
+                throw new ArgumentNullException(nameof(shuffleAlgorithm), "The shuffling algorithm to use cannot be null.");
+            }
+
+            ShuffleInBase(other, shuffleAlgorithm);
+        }
+
         /// <summary>
         /// Shuffles the provided <paramref name="cards"/> into this
         /// <see cref="DrawPile{TCard}"/> using the supplied shuffling
@@ -529,20 +546,7 @@ namespace Xyaneon.Games.Cards
             ShuffleInBase(cards, shuffleAlgorithm);
         }
 
-        #endregion // End methods region.
-
-        #endregion // End IDrawPile<TCard> implementation region.
-
-        #region Fields
-
-        /// <summary>
-        /// Private backing field for the <see cref="Cards"/> property.
-        /// </summary>
-        private Stack<TCard> _cards;
-
-        #endregion // End fields region.
-
-        #region Methods
+        #endregion // End public methods region.
 
         #region Private methods
 

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -16,6 +16,7 @@ namespace Xyaneon.Games.Cards
     /// <see cref="IDrawPile{TCard}"/> interface.
     /// </remarks>
     /// <seealso cref="IDrawPile{TCard}"/>
+    /// <seealso cref="ShuffleFunction{TCard}"/>
     public class DrawPile<TCard> : IDrawPile<TCard> where TCard : Card
     {
         #region Constructors
@@ -466,7 +467,7 @@ namespace Xyaneon.Games.Cards
         /// <exception cref="ArgumentNullException">
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
-        public void Shuffle(Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        public void Shuffle(ShuffleFunction<TCard> shuffleAlgorithm)
         {
             if (shuffleAlgorithm == null)
             {
@@ -499,7 +500,7 @@ namespace Xyaneon.Games.Cards
         /// result of calling this algorithm.
         /// </para>
         /// </remarks>
-        public void ShuffleIn(IDrawPile<TCard> other, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        public void ShuffleIn(IDrawPile<TCard> other, ShuffleFunction<TCard> shuffleAlgorithm)
         {
             if (other == null)
             {
@@ -531,7 +532,7 @@ namespace Xyaneon.Games.Cards
         /// -or-
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
-        public void ShuffleIn(IEnumerable<TCard> cards, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        public void ShuffleIn(IEnumerable<TCard> cards, ShuffleFunction<TCard> shuffleAlgorithm)
         {
             if (cards == null)
             {
@@ -583,7 +584,7 @@ namespace Xyaneon.Games.Cards
             _cards = new Stack<TCard>(shuffledCards);
         }
 
-        private void ShuffleBase(Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        private void ShuffleBase(ShuffleFunction<TCard> shuffleAlgorithm)
         {
             IList<TCard> shuffledCards = shuffleAlgorithm(_cards);
             _cards = new Stack<TCard>(shuffledCards);
@@ -625,7 +626,7 @@ namespace Xyaneon.Games.Cards
             _cards = new Stack<TCard>(shuffledCards);
         }
 
-        private void ShuffleInBase(IDrawPile<TCard> other, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        private void ShuffleInBase(IDrawPile<TCard> other, ShuffleFunction<TCard> shuffleAlgorithm)
         {
             IEnumerable<TCard> cardsToShuffle = _cards.Concat(other.DrawAll());
             IList<TCard> shuffledCards = shuffleAlgorithm(cardsToShuffle);
@@ -664,7 +665,7 @@ namespace Xyaneon.Games.Cards
             _cards = new Stack<TCard>(shuffledCards);
         }
 
-        private void ShuffleInBase(IEnumerable<TCard> cards, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        private void ShuffleInBase(IEnumerable<TCard> cards, ShuffleFunction<TCard> shuffleAlgorithm)
         {
             IEnumerable<TCard> cardsToShuffle = _cards.Concat(cards);
             IList<TCard> shuffledCards = shuffleAlgorithm(cardsToShuffle);
@@ -675,4 +676,28 @@ namespace Xyaneon.Games.Cards
 
         #endregion // End methods region.
     }
+
+    /// <summary>
+    /// Encapsulates a method which takes a collection of cards, then returns
+    /// an ordered list of the same cards after shuffling them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The shuffling function should always return the same card instances it
+    /// was originally given in the <paramref name="cards"/> argument, but
+    /// most likely in a different order. Elements are expected not to be
+    /// added, removed or modified by the provided function, although strictly
+    /// speaking <see cref="DrawPile{TCard}"/> does not enforce this.
+    /// </para>
+    /// <para>
+    /// You do not need to define nor supply your own
+    /// <see cref="ShuffleFunction{TCard}"/> to shuffle instances of
+    /// <see cref="DrawPile{TCard}"/>. Omitting it will simply make
+    /// <see cref="DrawPile{TCard}"/> use an internal default. However, you
+    /// can create one if you desire specific shuffling behavior, or for
+    /// testing purposes.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="DrawPile{TCard}"/>
+    public delegate IList<TCard> ShuffleFunction<TCard>(IEnumerable<TCard> cards) where TCard : Card;
 }

--- a/Xyaneon.Games.Cards/DrawPile.cs
+++ b/Xyaneon.Games.Cards/DrawPile.cs
@@ -342,9 +342,8 @@ namespace Xyaneon.Games.Cards
         /// </exception>
         /// <remarks>
         /// <para>
-        /// This method will use the shuffling algorithm provided by the
-        /// <see cref="DefaultShuffleAlgorithm{TCard}"/>. If you want to use
-        /// a custom shuffling method instead, then consider using the
+        /// This method will use a default shuffling algorithm. If you want to
+        /// use a custom shuffling method instead, then consider using the
         /// <see cref="ShuffleIn(IEnumerable{TCard}, IShuffleAlgorithm{TCard})"/>
         /// overload method.
         /// </para>
@@ -360,7 +359,7 @@ namespace Xyaneon.Games.Cards
                 throw new ArgumentNullException(nameof(other), "The draw pile to shuffle into this draw pile cannot be null.");
             }
 
-            ShuffleInBase(other, new DefaultShuffleAlgorithm<TCard>());
+            ShuffleInBase(other, DefaultShuffleAlgorithm);
         }
 
         /// <summary>
@@ -413,9 +412,8 @@ namespace Xyaneon.Games.Cards
         /// <paramref name="cards"/> is <see langword="null"/>.
         /// </exception>
         /// <remarks>
-        /// This method will use the shuffling algorithm provided by the
-        /// <see cref="DefaultShuffleAlgorithm{TCard}"/>. If you want to use
-        /// a custom shuffling method instead, then consider using the
+        /// This method will use the default shuffling algorithm. If you want
+        /// to use a custom shuffling method instead, then consider using the
         /// <see cref="ShuffleIn(IEnumerable{TCard}, IShuffleAlgorithm{TCard})"/>
         /// overload method.
         /// </remarks>
@@ -426,7 +424,7 @@ namespace Xyaneon.Games.Cards
                 throw new ArgumentNullException(nameof(cards), "The collection of cards to shuffle into this draw pile cannot be null.");
             }
 
-            ShuffleInBase(cards, new DefaultShuffleAlgorithm<TCard>());
+            ShuffleInBase(cards, DefaultShuffleAlgorithm);
         }
 
         /// <summary>
@@ -553,6 +551,13 @@ namespace Xyaneon.Games.Cards
             _cards = new Stack<TCard>(shuffledCards);
         }
 
+        private void ShuffleInBase(IDrawPile<TCard> other, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            IEnumerable<TCard> cardsToShuffle = _cards.Concat(other.DrawAll());
+            IList<TCard> shuffledCards = shuffleAlgorithm(cardsToShuffle);
+            _cards = new Stack<TCard>(shuffledCards);
+        }
+
         /// <summary>
         /// The base method for shuffling the supplied <paramref name="cards"/>
         /// into this <see cref="DrawPile{TCard}"/>. The
@@ -582,6 +587,13 @@ namespace Xyaneon.Games.Cards
         {
             IEnumerable<TCard> cardsToShuffle = _cards.Concat(cards);
             IList<TCard> shuffledCards = shuffleAlgorithm.Shuffle(cardsToShuffle);
+            _cards = new Stack<TCard>(shuffledCards);
+        }
+
+        private void ShuffleInBase(IEnumerable<TCard> cards, Func<IEnumerable<TCard>, IList<TCard>> shuffleAlgorithm)
+        {
+            IEnumerable<TCard> cardsToShuffle = _cards.Concat(cards);
+            IList<TCard> shuffledCards = shuffleAlgorithm(cardsToShuffle);
             _cards = new Stack<TCard>(shuffledCards);
         }
 

--- a/Xyaneon.Games.Cards/IDrawPile.cs
+++ b/Xyaneon.Games.Cards/IDrawPile.cs
@@ -162,6 +162,12 @@ namespace Xyaneon.Games.Cards
         /// <exception cref="ArgumentNullException">
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        /// This interface method is deprecated, and will be replaced by a new
+        /// one in an upcoming major release which will replace the usage of
+        /// <see cref="IShuffleAlgorithm{TCard}"/> with a named delegate type.
+        /// </remarks>
+        [Obsolete("IShuffleAlgorithm will be removed in favor of a named delegate in an upcoming major release.")]
         void Shuffle(IShuffleAlgorithm<TCard> shuffleAlgorithm);
 
         /// <summary>
@@ -212,7 +218,13 @@ namespace Xyaneon.Games.Cards
         /// <paramref name="other"/> will be emptied of all of its cards as a
         /// result of calling this algorithm.
         /// </para>
+        /// <para>
+        /// This interface method is deprecated, and will be replaced by a new
+        /// one in an upcoming major release which will replace the usage of
+        /// <see cref="IShuffleAlgorithm{TCard}"/> with a named delegate type.
+        /// </para>
         /// </remarks>
+        [Obsolete("IShuffleAlgorithm will be removed in favor of a named delegate in an upcoming major release.")]
         void ShuffleIn(IDrawPile<TCard> other, IShuffleAlgorithm<TCard> shuffleAlgorithm);
 
         /// <summary>
@@ -252,6 +264,12 @@ namespace Xyaneon.Games.Cards
         /// -or-
         /// <paramref name="shuffleAlgorithm"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        /// This interface method is deprecated, and will be replaced by a new
+        /// one in an upcoming major release which will replace the usage of
+        /// <see cref="IShuffleAlgorithm{TCard}"/> with a named delegate type.
+        /// </remarks>
+        [Obsolete("IShuffleAlgorithm will be removed in favor of a named delegate in an upcoming major release.")]
         void ShuffleIn(IEnumerable<TCard> cards, IShuffleAlgorithm<TCard> shuffleAlgorithm);
 
         #endregion // End methods region.

--- a/Xyaneon.Games.Cards/IShuffleAlgorithm.cs
+++ b/Xyaneon.Games.Cards/IShuffleAlgorithm.cs
@@ -9,6 +9,13 @@ namespace Xyaneon.Games.Cards
     /// <typeparam name="TCard">
     /// The <see cref="Type"/> of cards this algorithm will be used to shuffle.
     /// </typeparam>
+    /// <remarks>
+    /// This interface is deprecated and will be removed in an upcoming major
+    /// release. Instead, you should provide your own
+    /// <see cref="ShuffleFunction{TCard}"/> delegate implementations to the
+    /// shuffling methods on <see cref="DrawPile{TCard}"/> which accept one.
+    /// </remarks>
+    [Obsolete("This interface is deprecated. Instead, provide your own ShuffleFunction<TCard> delegate implementation to DrawPile<TCard> shuffling methods which accept one.")]
     public interface IShuffleAlgorithm<TCard> where TCard : Card
     {
         #region Methods


### PR DESCRIPTION
Fixes #62.

At a high level, this includes:
- Adding `DrawPile<TCard>` shuffling methods which take the custom shuffle algorithm to use as a `ShuffleFunction<TCard>` delegate
- Marking `IShuffleAlgorithm<TCard>` and its usages as deprecated (to be removed in a future major release under SemVer)
- Added unit testing coverage and some custom assertions refactoring